### PR TITLE
Repaired piercing usability problems

### DIFF
--- a/compendium/dungeonworld.monsters-01-cavern-dwellers.json
+++ b/compendium/dungeonworld.monsters-01-cavern-dwellers.json
@@ -8,7 +8,7 @@
 	},
 	"entries": [
 		{
-			"id": "Cloaker",
+			"id": "Choker",
 			"name": "Ahogador",
 			"attributes": {
 				"damage": {
@@ -80,7 +80,7 @@
 			"name": "Cubo Gelatinoso",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Transparente"
@@ -131,7 +131,7 @@
 			"name": "Escarabajo de Fuego",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Lleno de llamas"
@@ -165,7 +165,7 @@
 			"name": "Goblin Konjurador",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": ""
@@ -234,7 +234,7 @@
 			"name": "Manto",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Parecer un manto"
@@ -302,7 +302,7 @@
 			"name": "Rata de las Cavernas",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": ""

--- a/compendium/dungeonworld.monsters-02-swamp-denizens.json
+++ b/compendium/dungeonworld.monsters-02-swamp-denizens.json
@@ -12,7 +12,7 @@
 			"name": "Anguila de Fuego",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Aceite inflamable, Acuático"
@@ -29,7 +29,7 @@
 			"name": "Bakunawa",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Anfibio"
@@ -80,7 +80,7 @@
 			"name": "Couatl",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Alas, Halo"
@@ -267,7 +267,7 @@
 			"name": "Pudin Negro",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Amorfo"
@@ -301,7 +301,7 @@
 			"name": "Sajuagin",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Anfibio"

--- a/compendium/dungeonworld.monsters-03-undead-legions.json
+++ b/compendium/dungeonworld.monsters-03-undead-legions.json
@@ -63,7 +63,7 @@
 			"name": "Dragón de Hueso",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 3"
+					"piercing": "3 piercing"
 				},
 				"specialQualities": {
 					"value": ""
@@ -148,7 +148,7 @@
 			"name": "Gul",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": ""
@@ -165,7 +165,7 @@
 			"name": "Liche",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": ""
@@ -182,7 +182,7 @@
 			"name": "Lobo Espectral",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Forma de sombra"
@@ -284,7 +284,7 @@
 			"name": "Vampiro",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Cambiar de forma, Mente antigua"

--- a/compendium/dungeonworld.monsters-04-dark-woods.json
+++ b/compendium/dungeonworld.monsters-04-dark-woods.json
@@ -12,7 +12,7 @@
 			"name": "Centauro",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Mitad caballo, Mitad hombre"
@@ -29,7 +29,7 @@
 			"name": "Cieno del Caos",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Cieno, Fragmentos de otros planos incrustados en él"
@@ -80,7 +80,7 @@
 			"name": "Elfo, Alto Arcanista",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Sentidos aguzados"
@@ -114,7 +114,7 @@
 			"name": "Enredadera Asesina",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Planta"
@@ -182,7 +182,7 @@
 			"name": "Hombre Lobo",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Debilidad a la plata"
@@ -216,7 +216,7 @@
 			"name": "Jabalí Cuchilla",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 3"
+					"piercing": "3 piercing"
 				},
 				"specialQualities": {
 					"value": ""
@@ -267,7 +267,7 @@
 			"name": "Señor de las Águilas",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Alas poderosas"

--- a/compendium/dungeonworld.monsters-05-ravenous-hordes.json
+++ b/compendium/dungeonworld.monsters-05-ravenous-hordes.json
@@ -80,7 +80,7 @@
 			"name": "Gnoll Alfa",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Olor"
@@ -131,7 +131,7 @@
 			"name": "Orco Aplastador",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": ""
@@ -165,7 +165,7 @@
 			"name": "Orco, Cazador de Sombras",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Capa de sombras"
@@ -182,7 +182,7 @@
 			"name": "Orco, Chamán",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Poder elemental"
@@ -216,7 +216,7 @@
 			"name": "Orco, Guerrero de Sangre",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": ""
@@ -250,7 +250,7 @@
 			"name": "Orco, Un-Ojo",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Un ojo"
@@ -284,7 +284,7 @@
 			"name": "Tritón Invocador de Mareas",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Acuático, Mutaciones"

--- a/compendium/dungeonworld.monsters-06-twisted-experiments.json
+++ b/compendium/dungeonworld.monsters-06-twisted-experiments.json
@@ -46,7 +46,7 @@
 			"name": "Digestor",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Secreción ácida"
@@ -148,7 +148,7 @@
 			"name": "Mantícora",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": "Alas"
@@ -165,7 +165,7 @@
 			"name": "Monstruo Corrosivo",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Toque corrosivo"
@@ -233,7 +233,7 @@
 			"name": "Terrarón",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 3"
+					"piercing": "3 piercing"
 				},
 				"specialQualities": {
 					"value": "Dos cabezas"

--- a/compendium/dungeonworld.monsters-07-lower-depths.json
+++ b/compendium/dungeonworld.monsters-07-lower-depths.json
@@ -29,7 +29,7 @@
 			"name": "Desgarrador Gris",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 3"
+					"piercing": "3 piercing"
 				},
 				"specialQualities": {
 					"value": ""
@@ -46,7 +46,7 @@
 			"name": "Dragón",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 4"
+					"piercing": "4 piercing"
 				},
 				"specialQualities": {
 					"value": "Sangre elemental, Alas"
@@ -63,7 +63,7 @@
 			"name": "Dragón del Apocalipsis",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 4"
+					"piercing": "4 piercing"
 				},
 				"specialQualities": {
 					"value": "Piel metálica de dos centímetros y medio de grosor, Conocimiento sobrenatural, Alas"
@@ -80,7 +80,7 @@
 			"name": "Elfo Oscuro, Asesino",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": ""
@@ -97,7 +97,7 @@
 			"name": "Elfo Oscuro, Maestro de la Espada",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 1"
+					"piercing": "1 piercing"
 				},
 				"specialQualities": {
 					"value": ""

--- a/compendium/dungeonworld.monsters-08-planar-powers.json
+++ b/compendium/dungeonworld.monsters-08-planar-powers.json
@@ -12,7 +12,7 @@
 			"name": "Ángel",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Alas"
@@ -63,7 +63,7 @@
 			"name": "Diablillo",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": ""
@@ -80,7 +80,7 @@
 			"name": "Diablo Encadenado",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": ""
@@ -97,7 +97,7 @@
 			"name": "Diablo Punzante",
 			"attributes": {
 				"damage": {
-					"piercing": "penetrante 3"
+					"piercing": "3 piercing"
 				},
 				"specialQualities": {
 					"value": "Púas"
@@ -114,7 +114,7 @@
 			"name": "Djinn",
 			"attributes": {
 				"damage": {
-					"piercing": "ignora armadura"
+					"piercing": "ignores armor"
 				},
 				"specialQualities": {
 					"value": "Hecho en llamas"


### PR DESCRIPTION
Hola.
Mediante la detección del usuario "cal" de discord ha reparado problemas de usabilidad en el atributo <<piercing>>, ya que el algoritmo no reconocía las etiquetas <<ignora armadura>> o <<penetrante n>> y se ha tenido que dejar en su original en inglés.
Saludos.